### PR TITLE
Add registration link and create register.ctp view

### DIFF
--- a/boilerplate/src/Locale/lt/default.po
+++ b/boilerplate/src/Locale/lt/default.po
@@ -452,6 +452,9 @@ msgstr "El. paštas"
 msgid "register.password"
 msgstr "Slaptažodis"
 
+msgid "register.submit"
+msgstr "Užsiregistruoti"
+
 msgid "layout.documentation"
 msgstr "Dokumentacija"
 

--- a/boilerplate/src/Template/Users/login.ctp
+++ b/boilerplate/src/Template/Users/login.ctp
@@ -8,7 +8,7 @@
     </fieldset>
     <?= $this->Form->button(__('login.button')); ?>
     <?= $this->Form->end() ?>
-    <?= $this->Html->link(__('login.register_link'), ['action' => 'add']) ?>
+    <?= $this->Html->link(__('login.register_link'), ['action' => 'register']) ?>
 
     <div style="margin-top: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 5px;">
         <h4><?= __('login.test_credentials.title') ?></h4>

--- a/boilerplate/src/Template/Users/register.ctp
+++ b/boilerplate/src/Template/Users/register.ctp
@@ -1,0 +1,11 @@
+<div class="users form content">
+    <?= $this->Flash->render('auth') ?>
+    <?= $this->Form->create($user) ?>
+    <fieldset>
+        <legend><?= __('register.title') ?></legend>
+        <?= $this->Form->control('email', ['label' => __('register.email')]) ?>
+        <?= $this->Form->control('password', ['label' => __('register.password')]) ?>
+    </fieldset>
+    <?= $this->Form->button(__('register.submit')) ?>
+    <?= $this->Form->end() ?>
+</div>


### PR DESCRIPTION
**Problem:**

New users couldn't create an account because link on the login page pointed to the wrong action. Additionally there was no register.ctp view and localization for the button.

**Changes:**

1. Fixed the registration link on the login page (changed from 'add' to 'register') so users can actually find the sign-up page.
2. Created register.ctp with the registration form.
3. Added a locale entry for the submit button text: "Užsiregistruoti".

**Testing:**

1. Go to the login page.
2. Click on the “Don’t have an account? Sign up” link.
3. You should be redirected to the /users/register page.
4. The registration form should be visible with a submit button labeled “Užsiregistruoti”.